### PR TITLE
devDependencies bug introduced

### DIFF
--- a/lib/bower-files.js
+++ b/lib/bower-files.js
@@ -30,7 +30,7 @@ bowerFiles = function (options) {
   bower = require(options.json);
   dependencies = bower.dependencies;
   if (options.dev && bower.devDependencies) {
-    dependencies = _.merge(dependencies, bower.devDependencies)
+    dependencies = _.merge(dependencies, bower.devDependencies);
   }
   // Check to see that the project has dependencies
   files = processDependencies(dependencies, options.dir, bower.overrides);

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -25,6 +25,7 @@ defaults = function (options) {
     json: 'bower.json',
     dir: 'bower_components',
     ext: true,
+    dev: false,
     throw: false
   }, options);
   // resolves the paths to the given paths

--- a/test/bower-files-test.js
+++ b/test/bower-files-test.js
@@ -5,6 +5,7 @@ var should = require('should')
   , cwd    = process.cwd()
   , cd, getModule, deleteCache
   , devDependencies
+  , noDevDependencies
   , override
   , globs
   , justArray
@@ -103,6 +104,19 @@ devDependencies = function () {
   should(files).have.lengthOf(4);
 };
 
+// noDevDependencies
+// ---------------
+noDevDependencies = function () {
+  cd('dev-dependencies');
+  var files = getModule({
+    ext: 'js'
+  });
+
+  should(files).be.ok;
+  should(files).be.an.Array;
+  should(files).have.lengthOf(3);
+};
+
 // noBower
 // -------
 noBower = function () {
@@ -167,6 +181,7 @@ describe('bower-files tests', function () {
     it('should get list of files without being split by extension', justArray);
     it('should get only the files with a certain extension', justOneExt);
     it('should get devDependencies when option is given', devDependencies);
+    it('should not get devDependencies when option is not given', noDevDependencies);
   });
 
   describe('Level 2', function () {


### PR DESCRIPTION
I've recreated an issue I'm encountering after using the devDependencies release.

The issue is that once you pass in `dev: true` every subsequent list will return the dev dependencies even with `false` explicitly passed in.

The order of this test matters because it doesn't fail when `noDevDependencies` is run before the existing `devDependencies` test. 
