### PR TITLE
allow symlinks

### DIFF
--- a/lib/is-symlink.js
+++ b/lib/is-symlink.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var fs = require('fs');
+
+// isSymlink
+// ======
+//
+// Checkes to see if a file is a symbolic link
+//
+// ### Parameters
+//
+// - `filepath` (String) - The absolute filepath to check
+//
+// ### Returns
+//
+// - `fileIsSymlink` (Boolean) - True if the filepath is a symlink, false if
+//   otherwise
+function isSymlink(filepath) {
+  return fs.existsSync(filepath) && fs.lstatSync(filepath).isSymbolicLink();
+}
+
+module.exports = isSymlink;

--- a/lib/process-dependencies.js
+++ b/lib/process-dependencies.js
@@ -4,6 +4,7 @@ var path       = require('path');
 var glob       = require('glob');
 var _          = require('lodash');
 var exists     = require('./exists');
+var isSymlink  = require('./is-symlink');
 var removeDups = require('./remove-dups');
 
 // processDependencies
@@ -40,13 +41,17 @@ function processDependencies(dependencies, baseDir, overrides) {
     var componentBowerPath = path.join(componentPath, '.bower.json');
     var component, main, children;
 
-    if (!exists(componentBowerPath)) {
+    if (!exists(componentBowerPath) && !isSymlink(componentPath)) {
       files.error = new Error('Missing dependency "' + dependency + '"');
       return true;
     }
     // Try to get the component's .bower.json. If it doesn't exist, it likely
     // means that the user didn't use `bower install`
-    component = require(componentBowerPath);
+    if (exists(componentBowerPath)) {
+      component = require(componentBowerPath);
+    } else if (isSymlink(componentPath)) {
+      component = require(path.join(componentPath, 'bower.json'));
+    }
     // Get the child dependencies
     children = processDependencies(component.dependencies, baseDir, overrides);
     if (children.error) {


### PR DESCRIPTION
When developing bower dependencies for a project, it's common to use
`bower link` to create symbolic links to the development directory for a 
specific package. It would be useful for bower-files to suppor this.
