### PR TITLE
Fix overrides without main field

### DIFF
--- a/lib/process-dependencies.js
+++ b/lib/process-dependencies.js
@@ -63,7 +63,7 @@ function processDependencies(dependencies, baseDir, overrides) {
     }
     files.paths = files.paths.concat(children.paths);
     // Get the main property
-    main = overrides[dependency] ? overrides[dependency].main : component.main;
+    main = (overrides[dependency] && overrides[dependency].main) || component.main;
     // If main doesn't exist, we ned to let the user know to add it to the
     // package file
     if (!main) {


### PR DESCRIPTION
bower-files fails if the `bower.json` file specifies an `overrides` setting for a package that does not include a `main` property for that package:

```
 Error: Invalid glob argument: Error: No main property: "PACKAGE-NAME". Add to the overrides property in your component package file.
```

The attached pull request fixes the problem by replacing the tertiary assignment operator with a fall-through assignment that has the desired behavior (use `overrides.main` if defined, else use `component.main`)
