### PR TITLE
Support the case when the extension name matches no files

### DIFF
--- a/lib/file-filter.js
+++ b/lib/file-filter.js
@@ -137,8 +137,8 @@ function patternMatch(files, patterns) {
   return files;
 }
 
-function extensionSplit(files, ext, join) {
-  if (!ext || ext.length === 0) { return files; }
+function extensionSplit(files, exts, join) {
+  if (!exts || exts.length === 0) { return files; }
   // Split files up by extension
   files = files.reduce(function (files, file) {
     var ext = path.extname(file).substr(1);
@@ -156,9 +156,9 @@ function extensionSplit(files, ext, join) {
     }, files[joinExt]);
   });
   // if extension is an array of strings, get the extensions given
-  if (ext.length) {
-    files = ext.reduce(function (extArray, ext) {
-      return extArray.concat(files[ext]);
+  if (exts.length) {
+    files = exts.reduce(function (extArray, ext) {
+      return extArray.concat(files[ext] || []);
     }, []);
   }
   return files;

--- a/test/bower-files.js
+++ b/test/bower-files.js
@@ -304,6 +304,12 @@ describe('BowerFiles', function () {
       ]);
     });
 
+    it('should get no files when extension matches nothing', function () {
+      cd('default');
+      var files = new BowerFiles();
+      expect(files.ext('unknown-extension').files).to.be.eql([]);
+    });
+
   });
 
 });


### PR DESCRIPTION
* I added the test case when the specified extension name matches no files. In this case, `.file` property should return an empty array (`[ ]`). But current version [doesn't pass the test](https://travis-ci.org/ksmithut/bower-files/builds/47051882).
* I fixed file filter to support the case. It [passes the test](https://travis-ci.org/ksmithut/bower-files/builds/47052113).