### PR TITLE
Added support for relative file paths output

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,16 @@ lib.self().files;
 lib.self().deps;
 ```
 
+#### `lib.relative('/')`
+
+Default: process.cwd()
+
+Converts the file paths to be relative to the provided path, defaults to process.cwd()
+
+```javascript
+lib.relative(__dirname).files;
+```
+
 #### `lib.dev()`
 
 This throws in your `devDependencies`. Right now they come before the normal

--- a/lib/file-filter.js
+++ b/lib/file-filter.js
@@ -98,6 +98,15 @@ filter.dev = boolOption('dev', true);
  */
 filter.self = boolOption('self', true);
 
+/**
+ * @function FileFilter.relative
+ */
+filter.relative = function(val) {
+    var self = this._filter();
+    self.options.relative = val ? val : process.cwd();
+    return self;
+};
+
 function boolOption(name, defaultVal) {
   return function (val) {
     var self = this._filter();
@@ -143,9 +152,18 @@ Object.defineProperty(filter, 'files', {
     // Use ext option
     // If it's an array and it has a length greater than 1
     files = extensionSplit(files, self.options.ext, self.options.join);
+    if (self.options.relative) {
+        files = makeRelative(files, self.options.relative);
+    }
     return files;
   }
 });
+
+function makeRelative(files, cwd) {
+    return files.map(function(file) {
+        return path.relative(cwd, file);
+    });
+}
 
 function patternMatch(files, patterns) {
   patterns.forEach(function (pattern) {

--- a/test/bower-files.js
+++ b/test/bower-files.js
@@ -256,6 +256,25 @@ describe('BowerFiles', function () {
       });
     });
 
+    it('should get relative files', function () {
+      cd('default');
+      var files = new BowerFiles();
+      var dir   = 'bower_components';
+      var bs    = 'bootstrap';
+      expect(files.relative().ext('js').files).to.be.eql([
+        path.join(dir, 'jquery', 'dist', 'jquery.js'),
+        path.join(dir, bs, 'dist', 'js', 'bootstrap.js'),
+        path.join(dir, 'angular', 'angular.js'),
+        path.join(dir, 'angular-route', 'angular-route.js')
+      ]);
+      expect(files.relative(path.join(process.cwd(), '..')).ext('js').files).to.be.eql([
+        path.join('default', dir, 'jquery', 'dist', 'jquery.js'),
+        path.join('default', dir, bs, 'dist', 'js', 'bootstrap.js'),
+        path.join('default', dir, 'angular', 'angular.js'),
+        path.join('default', dir, 'angular-route', 'angular-route.js')
+      ]);
+    });
+
     it('should join file extensions', function () {
       cd('default');
       var files   = new BowerFiles();


### PR DESCRIPTION
This adds a file transformation function that can make the .files relative to a specific directory or process.cwd() (by default). Wasn't sure if you wanted it as an option, or a filter. Filter was cleaner to do, so went that route. Thoughts?