### PR TITLE
FileFilter Caching

### DIFF
--- a/lib/file-filter.js
+++ b/lib/file-filter.js
@@ -14,15 +14,15 @@ var BowerFiles = require('./bower-files');
  * @description A separate class is used in order to be able to use the
  * chainable methods without modifying the contents that come out.
  */
-function FileFilter(bowerFiles) {
+function FileFilter(bowerFiles, options) {
   if (this instanceof BowerFiles) { return; }
   this.bowerFiles = bowerFiles;
-  this.options = {
+  this.options = assign({
     ext: [],
     match: [],
     join: {},
     camelCase: this.bowerFiles._config.camelCase
-  };
+  }, options || {});
 }
 
 var filter = FileFilter.prototype;
@@ -31,8 +31,11 @@ var filter = FileFilter.prototype;
  * @description Used to the the File Filter out of bowerFiles
  */
 filter._filter = function () {
-  if (this instanceof BowerFiles) { return new FileFilter(this); }
-  return this;
+  if (this instanceof BowerFiles) {
+      return new FileFilter(this);
+  } else {
+      return new FileFilter(this.bowerFiles, this.options);
+  }
 };
 
 /**

--- a/test/bower-files.js
+++ b/test/bower-files.js
@@ -287,6 +287,29 @@ describe('BowerFiles', function () {
       ]);
     });
 
+    it('should allow caching filters', function () {
+      cd('default');
+      var files = new BowerFiles();
+      var cwd   = process.cwd();
+      var dir   = path.join(cwd, 'bower_components');
+      var bs    = path.join(dir, 'bootstrap');
+      var self  = files.self();
+      var js    = self.ext('js');
+      var css   = self.ext('css');
+      expect(js.files).to.be.eql([
+        path.join(dir, 'jquery', 'dist', 'jquery.js'),
+        path.join(bs, 'dist', 'js', 'bootstrap.js'),
+        path.join(dir, 'angular', 'angular.js'),
+        path.join(dir, 'angular-route', 'angular-route.js'),
+        path.join(cwd, 'dist', 'helpers.js'),
+        path.join(cwd, 'dist', 'main.js')
+      ]);
+      expect(css.files).to.be.eql([
+        path.join(bs, 'dist', 'css', 'bootstrap.css')
+      ]);
+    });
+
+
     it('should use all the options in a filter command', function () {
       cd('default');
       var files = new BowerFiles();


### PR DESCRIPTION
This pull request adds a feature where every new filter added to the FileFilter copies all the options before modifying them so you can cache/save/reuse any part of the chain. Allows for something like this

```
var lib = require('bower-files')();
var self = lib.self();
var js = self.js();
var css = self.css();
```

without polluting prior filters.

Thoughts?