### PR TITLE
Updated readme to reflect binary file name change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ module.exports = function (grunt) {
 };
 ```
 
-or via the CLI
+or via the CLI (`bower-components/.bin` needs to be in your `PATH`):
 
 ```sh
-$ bower-ls js css
+$ bower-files js css
 ```
 
 *Other Solutions*

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ module.exports = function (grunt) {
 };
 ```
 
-or via the CLI (`bower-components/.bin` needs to be in your `PATH`):
+or via the CLI (`node-modules/.bin` needs to be in your `PATH`):
 
 ```sh
 $ bower-files js css


### PR DESCRIPTION
The binary file to call from the shell is named `bower-files`, not `bower-ls`.